### PR TITLE
Added disable to child app

### DIFF
--- a/apps/Advanced Button Controller (ABC)/ABC_Child_Creator.groovy
+++ b/apps/Advanced Button Controller (ABC)/ABC_Child_Creator.groovy
@@ -7,6 +7,7 @@
  *
  *	Author: SmartThings, modified by Bruce Ravenel, Dale Coffing, Stephan Hackett
  * 
+ *  03/05/19 - added disable option
  *
  *	02/19/19 - rules api bug squashed
  *
@@ -150,6 +151,7 @@ def chooseButton() {
 			input "days", "enum", title: "Only on certain days of the week", multiple: true, required: false,
 					options: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 			input "modes", "mode", title: "Only when mode is", multiple: true, required: false
+			input "disable", "bool", title: "Disable This Mapping", required: false
 		}
 	}
 }
@@ -655,12 +657,17 @@ def cyclePlaylist(devices){
 }
 // execution filter methods
 private getAllOk() {
-	modeOk && daysOk && timeOk
+	modeOk && daysOk && timeOk && disableOk
 }
 
 private getModeOk() {
 	def result = !modes || modes.contains(location.mode)
 	if(logEnable) log.debug "modeOk = $result"
+	result
+}
+private getDisableOk() {
+	def result = !disable
+	if(logEnable) log.debug "disableOk = $result"
 	result
 }
 


### PR DESCRIPTION
Added disable option in child app.

In order to be able to test a new button controller, you have to delete the one you have.  I created a simple bool option along with the other limiting options to disable the whole app.  Tiny little change.  Thought I would share because it was helpful for me.  Feel free to not add if you don't want.  Thanks for the wonderful app.