### PR TITLE
Add new Hubitat 'menu: "Automations"' field to the App definition metadata.

### DIFF
--- a/apps/Advanced Button Controller (ABC)/ABC_Child_Creator.groovy
+++ b/apps/Advanced Button Controller (ABC)/ABC_Child_Creator.groovy
@@ -7,6 +7,8 @@
  *
  *	Author: SmartThings, modified by Bruce Ravenel, Dale Coffing, Stephan Hackett
  *
+ *  04/03/26 - added new 'menu: "Automations"' to the app metadata to properly display this app as an Automation in HE 2.5.x menu
+ *
  *  01/09/22 - added support for RMv5 rules. Older versions are considered "legacy". Requires Hub v2.2.9 f/w or higher.
  *           - Thanks to @bertabcd1234 for guidance with the undocumented RMUtils v5 api.
  *
@@ -113,7 +115,7 @@
 
 import hubitat.helper.RMUtils
 
-def version(){"v0.2.220109"}
+def version(){"v0.2.260403"}
 
 definition(
     name: "ABC Button Mapping",
@@ -125,6 +127,7 @@ definition(
     iconUrl: "https://cdn.rawgit.com/stephack/ABC/master/resources/images/abc2.png",
     iconX2Url: "https://cdn.rawgit.com/stephack/ABC/master/resources/images/abc2.png",
     iconX3Url: "https://cdn.rawgit.com/stephack/ABC/master/resources/images/abc2.png",
+    menu: "Automations"
 )
 
 preferences {

--- a/apps/Advanced Button Controller (ABC)/Advanced_Button_Controller.groovy
+++ b/apps/Advanced Button Controller (ABC)/Advanced_Button_Controller.groovy
@@ -6,6 +6,7 @@
  *
  *	Author: Stephan Hackett
  * 
+ *  04/03/26 - added new 'menu: "Automations"' to the app metadata to properly display this app as an Automation in HE 2.5.x menu
  *	
  *	01/14/19 - added url to Raw code at the top of the parent/child apps
  *			 - adjusted logging
@@ -14,7 +15,7 @@
  *	07/03/18 - added pictures and Update check
  * 
  */
-def version(){"v0.2.190114"}
+def version(){"v0.2.260403"}
 
 definition(
     name: "Advanced Button Controller",
@@ -26,6 +27,7 @@ definition(
     iconUrl: "https://cdn.rawgit.com/stephack/ABC/master/resources/images/abc2.png",
     iconX2Url: "https://cdn.rawgit.com/stephack/ABC/master/resources/images/abc2.png",
     iconX3Url: "https://cdn.rawgit.com/stephack/ABC/master/resources/images/abc2.png",
+    menu: "Automations"
 )
 
 preferences {

--- a/apps/Advanced Button Controller (ABC)/child.json
+++ b/apps/Advanced Button Controller (ABC)/child.json
@@ -1,5 +1,5 @@
 {
-  "currVersion": "v0.2.220109",
+  "currVersion": "v0.2.260403",
   
   "rawCode":
   "<small><a href='https://raw.githubusercontent.com/stephack/Hubitat/master/apps/Advanced%20Button%20Controller%20(ABC)/ABC_Child_Creator.groovy' target='_blank'>  [Raw Code]</a></small>",

--- a/apps/Advanced Button Controller (ABC)/parent.json
+++ b/apps/Advanced Button Controller (ABC)/parent.json
@@ -1,5 +1,5 @@
 {
-  "currVersion": "v0.2.190114",
+  "currVersion": "v0.2.260403",
   
   "rawCode":
   "<small><a href='https://raw.githubusercontent.com/stephack/Hubitat/master/apps/Advanced%20Button%20Controller%20(ABC)/Advanced_Button_Controller.groovy' target='_blank'>  [Raw Code]</a></small>",


### PR DESCRIPTION
In Hubitat platform version 2.5.x (currently in Beta testing), Hubitat has decided to subdivide the list of installed Apps into three categories - Integrations, Automations, and Apps (default).  Since the ABC app is truly an Automation, this update is a tiny tweak to allow it to be properly displayed in the new UI.

We may want to wait a little while to make sure that Hubitat does not decide to change anything with respect to this new feature.  So please feel free to sit on this Pull Request.  I just was thinking about this new feature and immediately thought of your ABC app when it didn't appear in their new Automations list.  I wanted to get it coded up and tested before I forgot about it.  